### PR TITLE
Fixed Compose Files For Experiments

### DIFF
--- a/lab-environment/docker-compose-exp-JPG-trial-0.yaml
+++ b/lab-environment/docker-compose-exp-JPG-trial-0.yaml
@@ -1,9 +1,4 @@
 version: '3'
-networks:
-  pdc-net: # Docker-only overlay network
-    ipam:
-      config:
-        - subnet: 172.23.0.0/16
 
 services:
   router1:
@@ -11,55 +6,60 @@ services:
     environment:
       - CLIENT_LISTEN_PORT=5555
       - COUNTERPARTY_LISTEN_PORT=6666
-      - COUNTERPARTY_HOST=172.23.0.6
+      - COUNTERPARTY_HOST=router2 # Use service name instead of IP address
       - COUNTERPARTY_HOST_PORT=6666
     build: ../Router
-    networks:
-      pdc-net:
-         ipv4_address: 172.23.0.5
+
   router2:
     hostname: router2
     environment:
       - CLIENT_LISTEN_PORT=5555
       - COUNTERPARTY_LISTEN_PORT=6666
-      - COUNTERPARTY_HOST=172.23.0.5
+      - COUNTERPARTY_HOST=router1 # Use service name instead of IP address
       - COUNTERPARTY_HOST_PORT=6666
     build: ../Router
-    networks:
-      pdc-net:
-         ipv4_address: 172.23.0.6
+
   p01a:
     hostname: p01a
     environment:
-      - ROUTER_HOSTNAME=172.23.0.5
+      - ROUTER_HOSTNAME=router1 # Use service name instead of IP address
       - FILE_NAME=/app/manhattan_soviet_map_512.jpg
-      - TARGET_NAME=p01b
+      - TARGET_NAME=p01b,p02b
     build: ../Peer
     volumes:
       - type: bind
         source: ./test-files/JPG/manhattan_soviet_map_512.jpg
         target: /app/manhattan_soviet_map_512.jpg
-    networks:
-      - pdc-net
     depends_on:
       - router1
       - router2
 
-
   p01b:
     hostname: p01b
     environment:
-      - ROUTER_HOSTNAME=172.23.0.6
+      - ROUTER_HOSTNAME=router2 # Use service name instead of IP address
     build: ../Peer
     volumes:
       - type: volume
         source: p01b
         target: /app
-    networks:
-      - pdc-net
+    depends_on:
+      - router1
+      - router2
+
+  p02b:
+    hostname: p02b
+    environment:
+      - ROUTER_HOSTNAME=router2 # Use service name instead of IP address
+    build: ../Peer
+    volumes:
+      - type: volume
+        source: p02b
+        target: /app
     depends_on:
       - router1
       - router2
 
 volumes:
   p01b:
+  p02b:

--- a/lab-environment/docker-compose-exp-JPG-trial-1.yaml
+++ b/lab-environment/docker-compose-exp-JPG-trial-1.yaml
@@ -1,9 +1,4 @@
 version: '3'
-networks:
-  pdc-net: # Docker-only overlay network
-    ipam:
-      config:
-        - subnet: 172.23.0.0/16
 
 services:
   router1:
@@ -11,55 +6,60 @@ services:
     environment:
       - CLIENT_LISTEN_PORT=5555
       - COUNTERPARTY_LISTEN_PORT=6666
-      - COUNTERPARTY_HOST=172.23.0.6
+      - COUNTERPARTY_HOST=router2 # Use service name instead of IP address
       - COUNTERPARTY_HOST_PORT=6666
     build: ../Router
-    networks:
-      pdc-net:
-         ipv4_address: 172.23.0.5
+
   router2:
     hostname: router2
     environment:
       - CLIENT_LISTEN_PORT=5555
       - COUNTERPARTY_LISTEN_PORT=6666
-      - COUNTERPARTY_HOST=172.23.0.5
+      - COUNTERPARTY_HOST=router1 # Use service name instead of IP address
       - COUNTERPARTY_HOST_PORT=6666
     build: ../Router
-    networks:
-      pdc-net:
-         ipv4_address: 172.23.0.6
+
   p01a:
     hostname: p01a
     environment:
-      - ROUTER_HOSTNAME=172.23.0.5
+      - ROUTER_HOSTNAME=router1 # Use service name instead of IP address
       - FILE_NAME=/app/manhattan_soviet_map_1024.jpg
-      - TARGET_NAME=p01b
+      - TARGET_NAME=p01b,p02b
     build: ../Peer
     volumes:
       - type: bind
         source: ./test-files/JPG/manhattan_soviet_map_1024.jpg
         target: /app/manhattan_soviet_map_1024.jpg
-    networks:
-      - pdc-net
     depends_on:
       - router1
       - router2
 
-
   p01b:
     hostname: p01b
     environment:
-      - ROUTER_HOSTNAME=172.23.0.6
+      - ROUTER_HOSTNAME=router2 # Use service name instead of IP address
     build: ../Peer
     volumes:
       - type: volume
         source: p01b
         target: /app
-    networks:
-      - pdc-net
+    depends_on:
+      - router1
+      - router2
+
+  p02b:
+    hostname: p02b
+    environment:
+      - ROUTER_HOSTNAME=router2 # Use service name instead of IP address
+    build: ../Peer
+    volumes:
+      - type: volume
+        source: p02b
+        target: /app
     depends_on:
       - router1
       - router2
 
 volumes:
   p01b:
+  p02b:

--- a/lab-environment/docker-compose-exp-JPG-trial-2.yaml
+++ b/lab-environment/docker-compose-exp-JPG-trial-2.yaml
@@ -1,9 +1,4 @@
 version: '3'
-networks:
-  pdc-net: # Docker-only overlay network
-    ipam:
-      config:
-        - subnet: 172.23.0.0/16
 
 services:
   router1:
@@ -11,55 +6,60 @@ services:
     environment:
       - CLIENT_LISTEN_PORT=5555
       - COUNTERPARTY_LISTEN_PORT=6666
-      - COUNTERPARTY_HOST=172.23.0.6
+      - COUNTERPARTY_HOST=router2 # Use service name instead of IP address
       - COUNTERPARTY_HOST_PORT=6666
     build: ../Router
-    networks:
-      pdc-net:
-         ipv4_address: 172.23.0.5
+
   router2:
     hostname: router2
     environment:
       - CLIENT_LISTEN_PORT=5555
       - COUNTERPARTY_LISTEN_PORT=6666
-      - COUNTERPARTY_HOST=172.23.0.5
+      - COUNTERPARTY_HOST=router1 # Use service name instead of IP address
       - COUNTERPARTY_HOST_PORT=6666
     build: ../Router
-    networks:
-      pdc-net:
-         ipv4_address: 172.23.0.6
+
   p01a:
     hostname: p01a
     environment:
-      - ROUTER_HOSTNAME=172.23.0.5
+      - ROUTER_HOSTNAME=router1 # Use service name instead of IP address
       - FILE_NAME=/app/manhattan_soviet_map_2048.jpg
-      - TARGET_NAME=p01b
+      - TARGET_NAME=p01b,p02b
     build: ../Peer
     volumes:
       - type: bind
         source: ./test-files/JPG/manhattan_soviet_map_2048.jpg
         target: /app/manhattan_soviet_map_2048.jpg
-    networks:
-      - pdc-net
     depends_on:
       - router1
       - router2
 
-
   p01b:
     hostname: p01b
     environment:
-      - ROUTER_HOSTNAME=172.23.0.6
+      - ROUTER_HOSTNAME=router2 # Use service name instead of IP address
     build: ../Peer
     volumes:
       - type: volume
         source: p01b
         target: /app
-    networks:
-      - pdc-net
+    depends_on:
+      - router1
+      - router2
+
+  p02b:
+    hostname: p02b
+    environment:
+      - ROUTER_HOSTNAME=router2 # Use service name instead of IP address
+    build: ../Peer
+    volumes:
+      - type: volume
+        source: p02b
+        target: /app
     depends_on:
       - router1
       - router2
 
 volumes:
   p01b:
+  p02b:

--- a/lab-environment/docker-compose-exp-JPG-trial-3.yaml
+++ b/lab-environment/docker-compose-exp-JPG-trial-3.yaml
@@ -1,9 +1,4 @@
 version: '3'
-networks:
-  pdc-net: # Docker-only overlay network
-    ipam:
-      config:
-        - subnet: 172.23.0.0/16
 
 services:
   router1:
@@ -11,55 +6,60 @@ services:
     environment:
       - CLIENT_LISTEN_PORT=5555
       - COUNTERPARTY_LISTEN_PORT=6666
-      - COUNTERPARTY_HOST=172.23.0.6
+      - COUNTERPARTY_HOST=router2 # Use service name instead of IP address
       - COUNTERPARTY_HOST_PORT=6666
     build: ../Router
-    networks:
-      pdc-net:
-         ipv4_address: 172.23.0.5
+
   router2:
     hostname: router2
     environment:
       - CLIENT_LISTEN_PORT=5555
       - COUNTERPARTY_LISTEN_PORT=6666
-      - COUNTERPARTY_HOST=172.23.0.5
+      - COUNTERPARTY_HOST=router1 # Use service name instead of IP address
       - COUNTERPARTY_HOST_PORT=6666
     build: ../Router
-    networks:
-      pdc-net:
-         ipv4_address: 172.23.0.6
+
   p01a:
     hostname: p01a
     environment:
-      - ROUTER_HOSTNAME=172.23.0.5
+      - ROUTER_HOSTNAME=router1 # Use service name instead of IP address
       - FILE_NAME=/app/manhattan_soviet_map_4096.jpg
-      - TARGET_NAME=p01b
+      - TARGET_NAME=p01b,p02b
     build: ../Peer
     volumes:
       - type: bind
         source: ./test-files/JPG/manhattan_soviet_map_4096.jpg
         target: /app/manhattan_soviet_map_4096.jpg
-    networks:
-      - pdc-net
     depends_on:
       - router1
       - router2
 
-
   p01b:
     hostname: p01b
     environment:
-      - ROUTER_HOSTNAME=172.23.0.6
+      - ROUTER_HOSTNAME=router2 # Use service name instead of IP address
     build: ../Peer
     volumes:
       - type: volume
         source: p01b
         target: /app
-    networks:
-      - pdc-net
+    depends_on:
+      - router1
+      - router2
+
+  p02b:
+    hostname: p02b
+    environment:
+      - ROUTER_HOSTNAME=router2 # Use service name instead of IP address
+    build: ../Peer
+    volumes:
+      - type: volume
+        source: p02b
+        target: /app
     depends_on:
       - router1
       - router2
 
 volumes:
   p01b:
+  p02b:

--- a/lab-environment/docker-compose-exp-MP3-trial-0.yaml
+++ b/lab-environment/docker-compose-exp-MP3-trial-0.yaml
@@ -1,9 +1,4 @@
 version: '3'
-networks:
-  pdc-net: # Docker-only overlay network
-    ipam:
-      config:
-        - subnet: 172.23.0.0/16
 
 services:
   router1:
@@ -11,55 +6,60 @@ services:
     environment:
       - CLIENT_LISTEN_PORT=5555
       - COUNTERPARTY_LISTEN_PORT=6666
-      - COUNTERPARTY_HOST=172.23.0.6
+      - COUNTERPARTY_HOST=router2 # Use service name instead of IP address
       - COUNTERPARTY_HOST_PORT=6666
     build: ../Router
-    networks:
-      pdc-net:
-         ipv4_address: 172.23.0.5
+
   router2:
     hostname: router2
     environment:
       - CLIENT_LISTEN_PORT=5555
       - COUNTERPARTY_LISTEN_PORT=6666
-      - COUNTERPARTY_HOST=172.23.0.5
+      - COUNTERPARTY_HOST=router1 # Use service name instead of IP address
       - COUNTERPARTY_HOST_PORT=6666
     build: ../Router
-    networks:
-      pdc-net:
-         ipv4_address: 172.23.0.6
+
   p01a:
     hostname: p01a
     environment:
-      - ROUTER_HOSTNAME=172.23.0.5
+      - ROUTER_HOSTNAME=router1 # Use service name instead of IP address
       - FILE_NAME=/app/never_gonna_hit_those_notes_32_kbps.mp3
-      - TARGET_NAME=p01b
+      - TARGET_NAME=p01b,p02b
     build: ../Peer
     volumes:
       - type: bind
         source: ./test-files/MP3/never_gonna_hit_those_notes_32_kbps.mp3
         target: /app/never_gonna_hit_those_notes_32_kbps.mp3
-    networks:
-      - pdc-net
     depends_on:
       - router1
       - router2
 
-
   p01b:
     hostname: p01b
     environment:
-      - ROUTER_HOSTNAME=172.23.0.6
+      - ROUTER_HOSTNAME=router2 # Use service name instead of IP address
     build: ../Peer
     volumes:
       - type: volume
         source: p01b
         target: /app
-    networks:
-      - pdc-net
+    depends_on:
+      - router1
+      - router2
+
+  p02b:
+    hostname: p02b
+    environment:
+      - ROUTER_HOSTNAME=router2 # Use service name instead of IP address
+    build: ../Peer
+    volumes:
+      - type: volume
+        source: p02b
+        target: /app
     depends_on:
       - router1
       - router2
 
 volumes:
   p01b:
+  p02b:

--- a/lab-environment/docker-compose-exp-MP3-trial-1.yaml
+++ b/lab-environment/docker-compose-exp-MP3-trial-1.yaml
@@ -1,9 +1,4 @@
 version: '3'
-networks:
-  pdc-net: # Docker-only overlay network
-    ipam:
-      config:
-        - subnet: 172.23.0.0/16
 
 services:
   router1:
@@ -11,55 +6,60 @@ services:
     environment:
       - CLIENT_LISTEN_PORT=5555
       - COUNTERPARTY_LISTEN_PORT=6666
-      - COUNTERPARTY_HOST=172.23.0.6
+      - COUNTERPARTY_HOST=router2 # Use service name instead of IP address
       - COUNTERPARTY_HOST_PORT=6666
     build: ../Router
-    networks:
-      pdc-net:
-         ipv4_address: 172.23.0.5
+
   router2:
     hostname: router2
     environment:
       - CLIENT_LISTEN_PORT=5555
       - COUNTERPARTY_LISTEN_PORT=6666
-      - COUNTERPARTY_HOST=172.23.0.5
+      - COUNTERPARTY_HOST=router1 # Use service name instead of IP address
       - COUNTERPARTY_HOST_PORT=6666
     build: ../Router
-    networks:
-      pdc-net:
-         ipv4_address: 172.23.0.6
+
   p01a:
     hostname: p01a
     environment:
-      - ROUTER_HOSTNAME=172.23.0.5
+      - ROUTER_HOSTNAME=router1 # Use service name instead of IP address
       - FILE_NAME=/app/never_gonna_hit_those_notes_64_kbps.mp3
-      - TARGET_NAME=p01b
+      - TARGET_NAME=p01b,p02b
     build: ../Peer
     volumes:
       - type: bind
         source: ./test-files/MP3/never_gonna_hit_those_notes_64_kbps.mp3
         target: /app/never_gonna_hit_those_notes_64_kbps.mp3
-    networks:
-      - pdc-net
     depends_on:
       - router1
       - router2
 
-
   p01b:
     hostname: p01b
     environment:
-      - ROUTER_HOSTNAME=172.23.0.6
+      - ROUTER_HOSTNAME=router2 # Use service name instead of IP address
     build: ../Peer
     volumes:
       - type: volume
         source: p01b
         target: /app
-    networks:
-      - pdc-net
+    depends_on:
+      - router1
+      - router2
+
+  p02b:
+    hostname: p02b
+    environment:
+      - ROUTER_HOSTNAME=router2 # Use service name instead of IP address
+    build: ../Peer
+    volumes:
+      - type: volume
+        source: p02b
+        target: /app
     depends_on:
       - router1
       - router2
 
 volumes:
   p01b:
+  p02b:

--- a/lab-environment/docker-compose-exp-MP3-trial-2.yaml
+++ b/lab-environment/docker-compose-exp-MP3-trial-2.yaml
@@ -1,9 +1,4 @@
 version: '3'
-networks:
-  pdc-net: # Docker-only overlay network
-    ipam:
-      config:
-        - subnet: 172.23.0.0/16
 
 services:
   router1:
@@ -11,55 +6,60 @@ services:
     environment:
       - CLIENT_LISTEN_PORT=5555
       - COUNTERPARTY_LISTEN_PORT=6666
-      - COUNTERPARTY_HOST=172.23.0.6
+      - COUNTERPARTY_HOST=router2 # Use service name instead of IP address
       - COUNTERPARTY_HOST_PORT=6666
     build: ../Router
-    networks:
-      pdc-net:
-         ipv4_address: 172.23.0.5
+
   router2:
     hostname: router2
     environment:
       - CLIENT_LISTEN_PORT=5555
       - COUNTERPARTY_LISTEN_PORT=6666
-      - COUNTERPARTY_HOST=172.23.0.5
+      - COUNTERPARTY_HOST=router1 # Use service name instead of IP address
       - COUNTERPARTY_HOST_PORT=6666
     build: ../Router
-    networks:
-      pdc-net:
-         ipv4_address: 172.23.0.6
+
   p01a:
     hostname: p01a
     environment:
-      - ROUTER_HOSTNAME=172.23.0.5
+      - ROUTER_HOSTNAME=router1 # Use service name instead of IP address
       - FILE_NAME=/app/never_gonna_hit_those_notes_128_kbps.mp3
-      - TARGET_NAME=p01b
+      - TARGET_NAME=p01b,p02b
     build: ../Peer
     volumes:
       - type: bind
         source: ./test-files/MP3/never_gonna_hit_those_notes_128_kbps.mp3
         target: /app/never_gonna_hit_those_notes_128_kbps.mp3
-    networks:
-      - pdc-net
     depends_on:
       - router1
       - router2
 
-
   p01b:
     hostname: p01b
     environment:
-      - ROUTER_HOSTNAME=172.23.0.6
+      - ROUTER_HOSTNAME=router2 # Use service name instead of IP address
     build: ../Peer
     volumes:
       - type: volume
         source: p01b
         target: /app
-    networks:
-      - pdc-net
+    depends_on:
+      - router1
+      - router2
+
+  p02b:
+    hostname: p02b
+    environment:
+      - ROUTER_HOSTNAME=router2 # Use service name instead of IP address
+    build: ../Peer
+    volumes:
+      - type: volume
+        source: p02b
+        target: /app
     depends_on:
       - router1
       - router2
 
 volumes:
   p01b:
+  p02b:

--- a/lab-environment/docker-compose-exp-MP4-trial-0.yaml
+++ b/lab-environment/docker-compose-exp-MP4-trial-0.yaml
@@ -1,9 +1,4 @@
 version: '3'
-networks:
-  pdc-net: # Docker-only overlay network
-    ipam:
-      config:
-        - subnet: 172.23.0.0/16
 
 services:
   router1:
@@ -11,55 +6,60 @@ services:
     environment:
       - CLIENT_LISTEN_PORT=5555
       - COUNTERPARTY_LISTEN_PORT=6666
-      - COUNTERPARTY_HOST=172.23.0.6
+      - COUNTERPARTY_HOST=router2 # Use service name instead of IP address
       - COUNTERPARTY_HOST_PORT=6666
     build: ../Router
-    networks:
-      pdc-net:
-         ipv4_address: 172.23.0.5
+
   router2:
     hostname: router2
     environment:
       - CLIENT_LISTEN_PORT=5555
       - COUNTERPARTY_LISTEN_PORT=6666
-      - COUNTERPARTY_HOST=172.23.0.5
+      - COUNTERPARTY_HOST=router1 # Use service name instead of IP address
       - COUNTERPARTY_HOST_PORT=6666
     build: ../Router
-    networks:
-      pdc-net:
-         ipv4_address: 172.23.0.6
+
   p01a:
     hostname: p01a
     environment:
-      - ROUTER_HOSTNAME=172.23.0.5
+      - ROUTER_HOSTNAME=router1 # Use service name instead of IP address
       - FILE_NAME=/app/shia_surprise_94_kbps_240p.mp4
-      - TARGET_NAME=p01b
+      - TARGET_NAME=p01b,p02b
     build: ../Peer
     volumes:
       - type: bind
-        source: ./test-files/PDF/shia_surprise_94_kbps_240p.mp4
+        source: ./test-files/MP4/shia_surprise_94_kbps_240p.mp4
         target: /app/shia_surprise_94_kbps_240p.mp4
-    networks:
-      - pdc-net
     depends_on:
       - router1
       - router2
 
-
   p01b:
     hostname: p01b
     environment:
-      - ROUTER_HOSTNAME=172.23.0.6
+      - ROUTER_HOSTNAME=router2 # Use service name instead of IP address
     build: ../Peer
     volumes:
       - type: volume
         source: p01b
         target: /app
-    networks:
-      - pdc-net
+    depends_on:
+      - router1
+      - router2
+
+  p02b:
+    hostname: p02b
+    environment:
+      - ROUTER_HOSTNAME=router2 # Use service name instead of IP address
+    build: ../Peer
+    volumes:
+      - type: volume
+        source: p02b
+        target: /app
     depends_on:
       - router1
       - router2
 
 volumes:
   p01b:
+  p02b:

--- a/lab-environment/docker-compose-exp-MP4-trial-1.yaml
+++ b/lab-environment/docker-compose-exp-MP4-trial-1.yaml
@@ -1,9 +1,4 @@
 version: '3'
-networks:
-  pdc-net: # Docker-only overlay network
-    ipam:
-      config:
-        - subnet: 172.23.0.0/16
 
 services:
   router1:
@@ -11,55 +6,60 @@ services:
     environment:
       - CLIENT_LISTEN_PORT=5555
       - COUNTERPARTY_LISTEN_PORT=6666
-      - COUNTERPARTY_HOST=172.23.0.6
+      - COUNTERPARTY_HOST=router2 # Use service name instead of IP address
       - COUNTERPARTY_HOST_PORT=6666
     build: ../Router
-    networks:
-      pdc-net:
-         ipv4_address: 172.23.0.5
+
   router2:
     hostname: router2
     environment:
       - CLIENT_LISTEN_PORT=5555
       - COUNTERPARTY_LISTEN_PORT=6666
-      - COUNTERPARTY_HOST=172.23.0.5
+      - COUNTERPARTY_HOST=router1 # Use service name instead of IP address
       - COUNTERPARTY_HOST_PORT=6666
     build: ../Router
-    networks:
-      pdc-net:
-         ipv4_address: 172.23.0.6
+
   p01a:
     hostname: p01a
     environment:
-      - ROUTER_HOSTNAME=172.23.0.5
+      - ROUTER_HOSTNAME=router1 # Use service name instead of IP address
       - FILE_NAME=/app/shia_surprise_375_kbps_540p.mp4
-      - TARGET_NAME=p01b
+      - TARGET_NAME=p01b,p02b
     build: ../Peer
     volumes:
       - type: bind
-        source: ./test-files/PDF/shia_surprise_375_kbps_540p.mp4
+        source: ./test-files/MP4/shia_surprise_375_kbps_540p.mp4
         target: /app/shia_surprise_375_kbps_540p.mp4
-    networks:
-      - pdc-net
     depends_on:
       - router1
       - router2
 
-
   p01b:
     hostname: p01b
     environment:
-      - ROUTER_HOSTNAME=172.23.0.6
+      - ROUTER_HOSTNAME=router2 # Use service name instead of IP address
     build: ../Peer
     volumes:
       - type: volume
         source: p01b
         target: /app
-    networks:
-      - pdc-net
+    depends_on:
+      - router1
+      - router2
+
+  p02b:
+    hostname: p02b
+    environment:
+      - ROUTER_HOSTNAME=router2 # Use service name instead of IP address
+    build: ../Peer
+    volumes:
+      - type: volume
+        source: p02b
+        target: /app
     depends_on:
       - router1
       - router2
 
 volumes:
   p01b:
+  p02b:

--- a/lab-environment/docker-compose-exp-MP4-trial-2.yaml
+++ b/lab-environment/docker-compose-exp-MP4-trial-2.yaml
@@ -1,9 +1,4 @@
 version: '3'
-networks:
-  pdc-net: # Docker-only overlay network
-    ipam:
-      config:
-        - subnet: 172.23.0.0/16
 
 services:
   router1:
@@ -11,55 +6,60 @@ services:
     environment:
       - CLIENT_LISTEN_PORT=5555
       - COUNTERPARTY_LISTEN_PORT=6666
-      - COUNTERPARTY_HOST=172.23.0.6
+      - COUNTERPARTY_HOST=router2 # Use service name instead of IP address
       - COUNTERPARTY_HOST_PORT=6666
     build: ../Router
-    networks:
-      pdc-net:
-         ipv4_address: 172.23.0.5
+
   router2:
     hostname: router2
     environment:
       - CLIENT_LISTEN_PORT=5555
       - COUNTERPARTY_LISTEN_PORT=6666
-      - COUNTERPARTY_HOST=172.23.0.5
+      - COUNTERPARTY_HOST=router1 # Use service name instead of IP address
       - COUNTERPARTY_HOST_PORT=6666
     build: ../Router
-    networks:
-      pdc-net:
-         ipv4_address: 172.23.0.6
+
   p01a:
     hostname: p01a
     environment:
-      - ROUTER_HOSTNAME=172.23.0.5
+      - ROUTER_HOSTNAME=router1 # Use service name instead of IP address
       - FILE_NAME=/app/shia_surprise_1500_kbps_1080p.mp4
-      - TARGET_NAME=p01b
+      - TARGET_NAME=p01b,p02b
     build: ../Peer
     volumes:
       - type: bind
-        source: ./test-files/PDF/shia_surprise_1500_kbps_1080p.mp4
+        source: ./test-files/MP4/shia_surprise_1500_kbps_1080p.mp4
         target: /app/shia_surprise_1500_kbps_1080p.mp4
-    networks:
-      - pdc-net
     depends_on:
       - router1
       - router2
 
-
   p01b:
     hostname: p01b
     environment:
-      - ROUTER_HOSTNAME=172.23.0.6
+      - ROUTER_HOSTNAME=router2 # Use service name instead of IP address
     build: ../Peer
     volumes:
       - type: volume
         source: p01b
         target: /app
-    networks:
-      - pdc-net
+    depends_on:
+      - router1
+      - router2
+
+  p02b:
+    hostname: p02b
+    environment:
+      - ROUTER_HOSTNAME=router2 # Use service name instead of IP address
+    build: ../Peer
+    volumes:
+      - type: volume
+        source: p02b
+        target: /app
     depends_on:
       - router1
       - router2
 
 volumes:
   p01b:
+  p02b:

--- a/lab-environment/docker-compose-exp-PDF-trial-0.yaml
+++ b/lab-environment/docker-compose-exp-PDF-trial-0.yaml
@@ -1,9 +1,4 @@
 version: '3'
-networks:
-  pdc-net: # Docker-only overlay network
-    ipam:
-      config:
-        - subnet: 172.23.0.0/16
 
 services:
   router1:
@@ -11,55 +6,60 @@ services:
     environment:
       - CLIENT_LISTEN_PORT=5555
       - COUNTERPARTY_LISTEN_PORT=6666
-      - COUNTERPARTY_HOST=172.23.0.6
+      - COUNTERPARTY_HOST=router2 # Use service name instead of IP address
       - COUNTERPARTY_HOST_PORT=6666
     build: ../Router
-    networks:
-      pdc-net:
-         ipv4_address: 172.23.0.5
+
   router2:
     hostname: router2
     environment:
       - CLIENT_LISTEN_PORT=5555
       - COUNTERPARTY_LISTEN_PORT=6666
-      - COUNTERPARTY_HOST=172.23.0.5
+      - COUNTERPARTY_HOST=router1 # Use service name instead of IP address
       - COUNTERPARTY_HOST_PORT=6666
     build: ../Router
-    networks:
-      pdc-net:
-         ipv4_address: 172.23.0.6
+
   p01a:
     hostname: p01a
     environment:
-      - ROUTER_HOSTNAME=172.23.0.5
+      - ROUTER_HOSTNAME=router1 # Use service name instead of IP address
       - FILE_NAME=/app/IPCC_AR6_SYR_4_pg.pdf
-      - TARGET_NAME=p01b
+      - TARGET_NAME=p01b,p02b
     build: ../Peer
     volumes:
       - type: bind
         source: ./test-files/PDF/IPCC_AR6_SYR_4_pg.pdf
         target: /app/IPCC_AR6_SYR_4_pg.pdf
-    networks:
-      - pdc-net
     depends_on:
       - router1
       - router2
 
-
   p01b:
     hostname: p01b
     environment:
-      - ROUTER_HOSTNAME=172.23.0.6
+      - ROUTER_HOSTNAME=router2 # Use service name instead of IP address
     build: ../Peer
     volumes:
       - type: volume
         source: p01b
         target: /app
-    networks:
-      - pdc-net
+    depends_on:
+      - router1
+      - router2
+
+  p02b:
+    hostname: p02b
+    environment:
+      - ROUTER_HOSTNAME=router2 # Use service name instead of IP address
+    build: ../Peer
+    volumes:
+      - type: volume
+        source: p02b
+        target: /app
     depends_on:
       - router1
       - router2
 
 volumes:
   p01b:
+  p02b:

--- a/lab-environment/docker-compose-exp-PDF-trial-1.yaml
+++ b/lab-environment/docker-compose-exp-PDF-trial-1.yaml
@@ -1,9 +1,4 @@
 version: '3'
-networks:
-  pdc-net: # Docker-only overlay network
-    ipam:
-      config:
-        - subnet: 172.23.0.0/16
 
 services:
   router1:
@@ -11,55 +6,60 @@ services:
     environment:
       - CLIENT_LISTEN_PORT=5555
       - COUNTERPARTY_LISTEN_PORT=6666
-      - COUNTERPARTY_HOST=172.23.0.6
+      - COUNTERPARTY_HOST=router2 # Use service name instead of IP address
       - COUNTERPARTY_HOST_PORT=6666
     build: ../Router
-    networks:
-      pdc-net:
-         ipv4_address: 172.23.0.5
+
   router2:
     hostname: router2
     environment:
       - CLIENT_LISTEN_PORT=5555
       - COUNTERPARTY_LISTEN_PORT=6666
-      - COUNTERPARTY_HOST=172.23.0.5
+      - COUNTERPARTY_HOST=router1 # Use service name instead of IP address
       - COUNTERPARTY_HOST_PORT=6666
     build: ../Router
-    networks:
-      pdc-net:
-         ipv4_address: 172.23.0.6
+
   p01a:
     hostname: p01a
     environment:
-      - ROUTER_HOSTNAME=172.23.0.5
+      - ROUTER_HOSTNAME=router1 # Use service name instead of IP address
       - FILE_NAME=/app/IPCC_AR6_SYR_8_pg.pdf
-      - TARGET_NAME=p01b
+      - TARGET_NAME=p01b,p02b
     build: ../Peer
     volumes:
       - type: bind
         source: ./test-files/PDF/IPCC_AR6_SYR_8_pg.pdf
         target: /app/IPCC_AR6_SYR_8_pg.pdf
-    networks:
-      - pdc-net
     depends_on:
       - router1
       - router2
 
-
   p01b:
     hostname: p01b
     environment:
-      - ROUTER_HOSTNAME=172.23.0.6
+      - ROUTER_HOSTNAME=router2 # Use service name instead of IP address
     build: ../Peer
     volumes:
       - type: volume
         source: p01b
         target: /app
-    networks:
-      - pdc-net
+    depends_on:
+      - router1
+      - router2
+
+  p02b:
+    hostname: p02b
+    environment:
+      - ROUTER_HOSTNAME=router2 # Use service name instead of IP address
+    build: ../Peer
+    volumes:
+      - type: volume
+        source: p02b
+        target: /app
     depends_on:
       - router1
       - router2
 
 volumes:
   p01b:
+  p02b:

--- a/lab-environment/docker-compose-exp-PDF-trial-2.yaml
+++ b/lab-environment/docker-compose-exp-PDF-trial-2.yaml
@@ -1,9 +1,4 @@
 version: '3'
-networks:
-  pdc-net: # Docker-only overlay network
-    ipam:
-      config:
-        - subnet: 172.23.0.0/16
 
 services:
   router1:
@@ -11,55 +6,60 @@ services:
     environment:
       - CLIENT_LISTEN_PORT=5555
       - COUNTERPARTY_LISTEN_PORT=6666
-      - COUNTERPARTY_HOST=172.23.0.6
+      - COUNTERPARTY_HOST=router2 # Use service name instead of IP address
       - COUNTERPARTY_HOST_PORT=6666
     build: ../Router
-    networks:
-      pdc-net:
-         ipv4_address: 172.23.0.5
+
   router2:
     hostname: router2
     environment:
       - CLIENT_LISTEN_PORT=5555
       - COUNTERPARTY_LISTEN_PORT=6666
-      - COUNTERPARTY_HOST=172.23.0.5
+      - COUNTERPARTY_HOST=router1 # Use service name instead of IP address
       - COUNTERPARTY_HOST_PORT=6666
     build: ../Router
-    networks:
-      pdc-net:
-         ipv4_address: 172.23.0.6
+
   p01a:
     hostname: p01a
     environment:
-      - ROUTER_HOSTNAME=172.23.0.5
+      - ROUTER_HOSTNAME=router1 # Use service name instead of IP address
       - FILE_NAME=/app/IPCC_AR6_SYR_16_pg.pdf
-      - TARGET_NAME=p01b
+      - TARGET_NAME=p01b,p02b
     build: ../Peer
     volumes:
       - type: bind
         source: ./test-files/PDF/IPCC_AR6_SYR_16_pg.pdf
         target: /app/IPCC_AR6_SYR_16_pg.pdf
-    networks:
-      - pdc-net
     depends_on:
       - router1
       - router2
 
-
   p01b:
     hostname: p01b
     environment:
-      - ROUTER_HOSTNAME=172.23.0.6
+      - ROUTER_HOSTNAME=router2 # Use service name instead of IP address
     build: ../Peer
     volumes:
       - type: volume
         source: p01b
         target: /app
-    networks:
-      - pdc-net
+    depends_on:
+      - router1
+      - router2
+
+  p02b:
+    hostname: p02b
+    environment:
+      - ROUTER_HOSTNAME=router2 # Use service name instead of IP address
+    build: ../Peer
+    volumes:
+      - type: volume
+        source: p02b
+        target: /app
     depends_on:
       - router1
       - router2
 
 volumes:
   p01b:
+  p02b:

--- a/lab-environment/docker-compose-exp-TXT-trial-0.yaml
+++ b/lab-environment/docker-compose-exp-TXT-trial-0.yaml
@@ -1,9 +1,4 @@
 version: '3'
-networks:
-  pdc-net: # Docker-only overlay network
-    ipam:
-      config:
-        - subnet: 172.23.0.0/16
 
 services:
   router1:
@@ -11,55 +6,60 @@ services:
     environment:
       - CLIENT_LISTEN_PORT=5555
       - COUNTERPARTY_LISTEN_PORT=6666
-      - COUNTERPARTY_HOST=172.23.0.6
+      - COUNTERPARTY_HOST=router2 # Use service name instead of IP address
       - COUNTERPARTY_HOST_PORT=6666
     build: ../Router
-    networks:
-      pdc-net:
-         ipv4_address: 172.23.0.5
+
   router2:
     hostname: router2
     environment:
       - CLIENT_LISTEN_PORT=5555
       - COUNTERPARTY_LISTEN_PORT=6666
-      - COUNTERPARTY_HOST=172.23.0.5
+      - COUNTERPARTY_HOST=router1 # Use service name instead of IP address
       - COUNTERPARTY_HOST_PORT=6666
     build: ../Router
-    networks:
-      pdc-net:
-         ipv4_address: 172.23.0.6
+
   p01a:
     hostname: p01a
     environment:
-      - ROUTER_HOSTNAME=172.23.0.5
+      - ROUTER_HOSTNAME=router1 # Use service name instead of IP address
       - FILE_NAME=/app/lorem_ipsum_7.5k.txt
-      - TARGET_NAME=p01b
+      - TARGET_NAME=p01b,p02b
     build: ../Peer
     volumes:
       - type: bind
         source: ./test-files/TXT/lorem_ipsum_7.5k.txt
         target: /app/lorem_ipsum_7.5k.txt
-    networks:
-      - pdc-net
     depends_on:
       - router1
       - router2
 
-
   p01b:
     hostname: p01b
     environment:
-      - ROUTER_HOSTNAME=172.23.0.6
+      - ROUTER_HOSTNAME=router2 # Use service name instead of IP address
     build: ../Peer
     volumes:
       - type: volume
         source: p01b
         target: /app
-    networks:
-      - pdc-net
+    depends_on:
+      - router1
+      - router2
+
+  p02b:
+    hostname: p02b
+    environment:
+      - ROUTER_HOSTNAME=router2 # Use service name instead of IP address
+    build: ../Peer
+    volumes:
+      - type: volume
+        source: p02b
+        target: /app
     depends_on:
       - router1
       - router2
 
 volumes:
   p01b:
+  p02b:

--- a/lab-environment/docker-compose-exp-TXT-trial-1.yaml
+++ b/lab-environment/docker-compose-exp-TXT-trial-1.yaml
@@ -1,9 +1,4 @@
 version: '3'
-networks:
-  pdc-net: # Docker-only overlay network
-    ipam:
-      config:
-        - subnet: 172.23.0.0/16
 
 services:
   router1:
@@ -11,55 +6,60 @@ services:
     environment:
       - CLIENT_LISTEN_PORT=5555
       - COUNTERPARTY_LISTEN_PORT=6666
-      - COUNTERPARTY_HOST=172.23.0.6
+      - COUNTERPARTY_HOST=router2 # Use service name instead of IP address
       - COUNTERPARTY_HOST_PORT=6666
     build: ../Router
-    networks:
-      pdc-net:
-         ipv4_address: 172.23.0.5
+
   router2:
     hostname: router2
     environment:
       - CLIENT_LISTEN_PORT=5555
       - COUNTERPARTY_LISTEN_PORT=6666
-      - COUNTERPARTY_HOST=172.23.0.5
+      - COUNTERPARTY_HOST=router1 # Use service name instead of IP address
       - COUNTERPARTY_HOST_PORT=6666
     build: ../Router
-    networks:
-      pdc-net:
-         ipv4_address: 172.23.0.6
+
   p01a:
     hostname: p01a
     environment:
-      - ROUTER_HOSTNAME=172.23.0.5
+      - ROUTER_HOSTNAME=router1 # Use service name instead of IP address
       - FILE_NAME=/app/lorem_ipsum_15k.txt
-      - TARGET_NAME=p01b
+      - TARGET_NAME=p01b,p02b
     build: ../Peer
     volumes:
       - type: bind
         source: ./test-files/TXT/lorem_ipsum_15k.txt
         target: /app/lorem_ipsum_15k.txt
-    networks:
-      - pdc-net
     depends_on:
       - router1
       - router2
 
-
   p01b:
     hostname: p01b
     environment:
-      - ROUTER_HOSTNAME=172.23.0.6
+      - ROUTER_HOSTNAME=router2 # Use service name instead of IP address
     build: ../Peer
     volumes:
       - type: volume
         source: p01b
         target: /app
-    networks:
-      - pdc-net
+    depends_on:
+      - router1
+      - router2
+
+  p02b:
+    hostname: p02b
+    environment:
+      - ROUTER_HOSTNAME=router2 # Use service name instead of IP address
+    build: ../Peer
+    volumes:
+      - type: volume
+        source: p02b
+        target: /app
     depends_on:
       - router1
       - router2
 
 volumes:
   p01b:
+  p02b:

--- a/lab-environment/docker-compose-exp-TXT-trial-2.yaml
+++ b/lab-environment/docker-compose-exp-TXT-trial-2.yaml
@@ -1,9 +1,4 @@
 version: '3'
-networks:
-  pdc-net: # Docker-only overlay network
-    ipam:
-      config:
-        - subnet: 172.23.0.0/16
 
 services:
   router1:
@@ -11,55 +6,60 @@ services:
     environment:
       - CLIENT_LISTEN_PORT=5555
       - COUNTERPARTY_LISTEN_PORT=6666
-      - COUNTERPARTY_HOST=172.23.0.6
+      - COUNTERPARTY_HOST=router2 # Use service name instead of IP address
       - COUNTERPARTY_HOST_PORT=6666
     build: ../Router
-    networks:
-      pdc-net:
-         ipv4_address: 172.23.0.5
+
   router2:
     hostname: router2
     environment:
       - CLIENT_LISTEN_PORT=5555
       - COUNTERPARTY_LISTEN_PORT=6666
-      - COUNTERPARTY_HOST=172.23.0.5
+      - COUNTERPARTY_HOST=router1 # Use service name instead of IP address
       - COUNTERPARTY_HOST_PORT=6666
     build: ../Router
-    networks:
-      pdc-net:
-         ipv4_address: 172.23.0.6
+
   p01a:
     hostname: p01a
     environment:
-      - ROUTER_HOSTNAME=172.23.0.5
+      - ROUTER_HOSTNAME=router1 # Use service name instead of IP address
       - FILE_NAME=/app/lorem_ipsum_30k.txt
-      - TARGET_NAME=p01b
+      - TARGET_NAME=p01b,p02b
     build: ../Peer
     volumes:
       - type: bind
         source: ./test-files/TXT/lorem_ipsum_30k.txt
         target: /app/lorem_ipsum_30k.txt
-    networks:
-      - pdc-net
     depends_on:
       - router1
       - router2
 
-
   p01b:
     hostname: p01b
     environment:
-      - ROUTER_HOSTNAME=172.23.0.6
+      - ROUTER_HOSTNAME=router2 # Use service name instead of IP address
     build: ../Peer
     volumes:
       - type: volume
         source: p01b
         target: /app
-    networks:
-      - pdc-net
+    depends_on:
+      - router1
+      - router2
+
+  p02b:
+    hostname: p02b
+    environment:
+      - ROUTER_HOSTNAME=router2 # Use service name instead of IP address
+    build: ../Peer
+    volumes:
+      - type: volume
+        source: p02b
+        target: /app
     depends_on:
       - router1
       - router2
 
 volumes:
   p01b:
+  p02b:

--- a/lab-environment/docker-compose-exp-TXT-trial-3.yaml
+++ b/lab-environment/docker-compose-exp-TXT-trial-3.yaml
@@ -1,9 +1,4 @@
 version: '3'
-networks:
-  pdc-net: # Docker-only overlay network
-    ipam:
-      config:
-        - subnet: 172.23.0.0/16
 
 services:
   router1:
@@ -11,55 +6,60 @@ services:
     environment:
       - CLIENT_LISTEN_PORT=5555
       - COUNTERPARTY_LISTEN_PORT=6666
-      - COUNTERPARTY_HOST=172.23.0.6
+      - COUNTERPARTY_HOST=router2 # Use service name instead of IP address
       - COUNTERPARTY_HOST_PORT=6666
     build: ../Router
-    networks:
-      pdc-net:
-         ipv4_address: 172.23.0.5
+
   router2:
     hostname: router2
     environment:
       - CLIENT_LISTEN_PORT=5555
       - COUNTERPARTY_LISTEN_PORT=6666
-      - COUNTERPARTY_HOST=172.23.0.5
+      - COUNTERPARTY_HOST=router1 # Use service name instead of IP address
       - COUNTERPARTY_HOST_PORT=6666
     build: ../Router
-    networks:
-      pdc-net:
-         ipv4_address: 172.23.0.6
+
   p01a:
     hostname: p01a
     environment:
-      - ROUTER_HOSTNAME=172.23.0.5
+      - ROUTER_HOSTNAME=router1 # Use service name instead of IP address
       - FILE_NAME=/app/lorem_ipsum_60k.txt
-      - TARGET_NAME=p01b
+      - TARGET_NAME=p01b,p02b
     build: ../Peer
     volumes:
       - type: bind
         source: ./test-files/TXT/lorem_ipsum_60k.txt
         target: /app/lorem_ipsum_60k.txt
-    networks:
-      - pdc-net
     depends_on:
       - router1
       - router2
 
-
   p01b:
     hostname: p01b
     environment:
-      - ROUTER_HOSTNAME=172.23.0.6
+      - ROUTER_HOSTNAME=router2 # Use service name instead of IP address
     build: ../Peer
     volumes:
       - type: volume
         source: p01b
         target: /app
-    networks:
-      - pdc-net
+    depends_on:
+      - router1
+      - router2
+
+  p02b:
+    hostname: p02b
+    environment:
+      - ROUTER_HOSTNAME=router2 # Use service name instead of IP address
+    build: ../Peer
+    volumes:
+      - type: volume
+        source: p02b
+        target: /app
     depends_on:
       - router1
       - router2
 
 volumes:
   p01b:
+  p02b:

--- a/lab-environment/docker-compose-exp-WAV-trial-0.yaml
+++ b/lab-environment/docker-compose-exp-WAV-trial-0.yaml
@@ -1,9 +1,4 @@
 version: '3'
-networks:
-  pdc-net: # Docker-only overlay network
-    ipam:
-      config:
-        - subnet: 172.23.0.0/16
 
 services:
   router1:
@@ -11,55 +6,60 @@ services:
     environment:
       - CLIENT_LISTEN_PORT=5555
       - COUNTERPARTY_LISTEN_PORT=6666
-      - COUNTERPARTY_HOST=172.23.0.6
+      - COUNTERPARTY_HOST=router2 # Use service name instead of IP address
       - COUNTERPARTY_HOST_PORT=6666
     build: ../Router
-    networks:
-      pdc-net:
-         ipv4_address: 172.23.0.5
+
   router2:
     hostname: router2
     environment:
       - CLIENT_LISTEN_PORT=5555
       - COUNTERPARTY_LISTEN_PORT=6666
-      - COUNTERPARTY_HOST=172.23.0.5
+      - COUNTERPARTY_HOST=router1 # Use service name instead of IP address
       - COUNTERPARTY_HOST_PORT=6666
     build: ../Router
-    networks:
-      pdc-net:
-         ipv4_address: 172.23.0.6
+
   p01a:
     hostname: p01a
     environment:
-      - ROUTER_HOSTNAME=172.23.0.5
+      - ROUTER_HOSTNAME=router1 # Use service name instead of IP address
       - FILE_NAME=/app/never_gonna_hit_those_notes_pcm_s16le.wav
-      - TARGET_NAME=p01b
+      - TARGET_NAME=p01b,p02b
     build: ../Peer
     volumes:
       - type: bind
         source: ./test-files/WAV/never_gonna_hit_those_notes_pcm_s16le.wav
         target: /app/never_gonna_hit_those_notes_pcm_s16le.wav
-    networks:
-      - pdc-net
     depends_on:
       - router1
       - router2
 
-
   p01b:
     hostname: p01b
     environment:
-      - ROUTER_HOSTNAME=172.23.0.6
+      - ROUTER_HOSTNAME=router2 # Use service name instead of IP address
     build: ../Peer
     volumes:
       - type: volume
         source: p01b
         target: /app
-    networks:
-      - pdc-net
+    depends_on:
+      - router1
+      - router2
+
+  p02b:
+    hostname: p02b
+    environment:
+      - ROUTER_HOSTNAME=router2 # Use service name instead of IP address
+    build: ../Peer
+    volumes:
+      - type: volume
+        source: p02b
+        target: /app
     depends_on:
       - router1
       - router2
 
 volumes:
   p01b:
+  p02b:

--- a/lab-environment/docker-compose-exp-WAV-trial-1.yaml
+++ b/lab-environment/docker-compose-exp-WAV-trial-1.yaml
@@ -1,9 +1,4 @@
 version: '3'
-networks:
-  pdc-net: # Docker-only overlay network
-    ipam:
-      config:
-        - subnet: 172.23.0.0/16
 
 services:
   router1:
@@ -11,55 +6,60 @@ services:
     environment:
       - CLIENT_LISTEN_PORT=5555
       - COUNTERPARTY_LISTEN_PORT=6666
-      - COUNTERPARTY_HOST=172.23.0.6
+      - COUNTERPARTY_HOST=router2 # Use service name instead of IP address
       - COUNTERPARTY_HOST_PORT=6666
     build: ../Router
-    networks:
-      pdc-net:
-         ipv4_address: 172.23.0.5
+
   router2:
     hostname: router2
     environment:
       - CLIENT_LISTEN_PORT=5555
       - COUNTERPARTY_LISTEN_PORT=6666
-      - COUNTERPARTY_HOST=172.23.0.5
+      - COUNTERPARTY_HOST=router1 # Use service name instead of IP address
       - COUNTERPARTY_HOST_PORT=6666
     build: ../Router
-    networks:
-      pdc-net:
-         ipv4_address: 172.23.0.6
+
   p01a:
     hostname: p01a
     environment:
-      - ROUTER_HOSTNAME=172.23.0.5
+      - ROUTER_HOSTNAME=router1 # Use service name instead of IP address
       - FILE_NAME=/app/never_gonna_hit_those_notes_pcm_s32le.wav
-      - TARGET_NAME=p01b
+      - TARGET_NAME=p01b,p02b
     build: ../Peer
     volumes:
       - type: bind
         source: ./test-files/WAV/never_gonna_hit_those_notes_pcm_s32le.wav
         target: /app/never_gonna_hit_those_notes_pcm_s32le.wav
-    networks:
-      - pdc-net
     depends_on:
       - router1
       - router2
 
-
   p01b:
     hostname: p01b
     environment:
-      - ROUTER_HOSTNAME=172.23.0.6
+      - ROUTER_HOSTNAME=router2 # Use service name instead of IP address
     build: ../Peer
     volumes:
       - type: volume
         source: p01b
         target: /app
-    networks:
-      - pdc-net
+    depends_on:
+      - router1
+      - router2
+
+  p02b:
+    hostname: p02b
+    environment:
+      - ROUTER_HOSTNAME=router2 # Use service name instead of IP address
+    build: ../Peer
+    volumes:
+      - type: volume
+        source: p02b
+        target: /app
     depends_on:
       - router1
       - router2
 
 volumes:
   p01b:
+  p02b:

--- a/lab-environment/docker-compose-exp-WAV-trial-2.yaml
+++ b/lab-environment/docker-compose-exp-WAV-trial-2.yaml
@@ -1,9 +1,4 @@
 version: '3'
-networks:
-  pdc-net: # Docker-only overlay network
-    ipam:
-      config:
-        - subnet: 172.23.0.0/16
 
 services:
   router1:
@@ -11,55 +6,60 @@ services:
     environment:
       - CLIENT_LISTEN_PORT=5555
       - COUNTERPARTY_LISTEN_PORT=6666
-      - COUNTERPARTY_HOST=172.23.0.6
+      - COUNTERPARTY_HOST=router2 # Use service name instead of IP address
       - COUNTERPARTY_HOST_PORT=6666
     build: ../Router
-    networks:
-      pdc-net:
-         ipv4_address: 172.23.0.5
+
   router2:
     hostname: router2
     environment:
       - CLIENT_LISTEN_PORT=5555
       - COUNTERPARTY_LISTEN_PORT=6666
-      - COUNTERPARTY_HOST=172.23.0.5
+      - COUNTERPARTY_HOST=router1 # Use service name instead of IP address
       - COUNTERPARTY_HOST_PORT=6666
     build: ../Router
-    networks:
-      pdc-net:
-         ipv4_address: 172.23.0.6
+
   p01a:
     hostname: p01a
     environment:
-      - ROUTER_HOSTNAME=172.23.0.5
+      - ROUTER_HOSTNAME=router1 # Use service name instead of IP address
       - FILE_NAME=/app/never_gonna_hit_those_notes_pcm_u8.wav
-      - TARGET_NAME=p01b
+      - TARGET_NAME=p01b,p02b
     build: ../Peer
     volumes:
       - type: bind
         source: ./test-files/WAV/never_gonna_hit_those_notes_pcm_u8.wav
         target: /app/never_gonna_hit_those_notes_pcm_u8.wav
-    networks:
-      - pdc-net
     depends_on:
       - router1
       - router2
 
-
   p01b:
     hostname: p01b
     environment:
-      - ROUTER_HOSTNAME=172.23.0.6
+      - ROUTER_HOSTNAME=router2 # Use service name instead of IP address
     build: ../Peer
     volumes:
       - type: volume
         source: p01b
         target: /app
-    networks:
-      - pdc-net
+    depends_on:
+      - router1
+      - router2
+
+  p02b:
+    hostname: p02b
+    environment:
+      - ROUTER_HOSTNAME=router2 # Use service name instead of IP address
+    build: ../Peer
+    volumes:
+      - type: volume
+        source: p02b
+        target: /app
     depends_on:
       - router1
       - router2
 
 volumes:
   p01b:
+  p02b:

--- a/lab-environment/docker-compose.yaml
+++ b/lab-environment/docker-compose.yaml
@@ -1,9 +1,4 @@
 version: '3'
-networks:
-  pdc-net: # Docker-only overlay network
-    ipam:
-      config:
-        - subnet: 172.23.0.0/16
 
 services:
   router1:
@@ -11,67 +6,56 @@ services:
     environment:
       - CLIENT_LISTEN_PORT=5555
       - COUNTERPARTY_LISTEN_PORT=6666
-      - COUNTERPARTY_HOST=172.23.0.6
+      - COUNTERPARTY_HOST=router2 # Use service name instead of IP address
       - COUNTERPARTY_HOST_PORT=6666
     build: ../Router
-    networks:
-      pdc-net:
-         ipv4_address: 172.23.0.5
+
   router2:
     hostname: router2
     environment:
       - CLIENT_LISTEN_PORT=5555
       - COUNTERPARTY_LISTEN_PORT=6666
-      - COUNTERPARTY_HOST=172.23.0.5
+      - COUNTERPARTY_HOST=router1 # Use service name instead of IP address
       - COUNTERPARTY_HOST_PORT=6666
     build: ../Router
-    networks:
-      pdc-net:
-         ipv4_address: 172.23.0.6
+
   p01a:
     hostname: p01a
     environment:
-      - ROUTER_HOSTNAME=172.23.0.5
+      - ROUTER_HOSTNAME=router1 # Use service name instead of IP address
       - FILE_NAME=/app/shia_surprise_94_kbps_240p.mp4
       - TARGET_NAME=p01b,p02b
-
     build: ../Peer
     volumes:
       - type: bind
         source: ./test-files/MP4/shia_surprise_94_kbps_240p.mp4
         target: /app/shia_surprise_94_kbps_240p.mp4
-    networks:
-      - pdc-net
     depends_on:
       - router1
       - router2
 
-
   p01b:
     hostname: p01b
     environment:
-      - ROUTER_HOSTNAME=172.23.0.6
+      - ROUTER_HOSTNAME=router2 # Use service name instead of IP address
     build: ../Peer
     volumes:
       - type: volume
         source: p01b
         target: /app
-    networks:
-      - pdc-net
     depends_on:
       - router1
       - router2
+
   p02b:
     hostname: p02b
     environment:
-      - ROUTER_HOSTNAME=172.23.0.6
+      - ROUTER_HOSTNAME=router2 # Use service name instead of IP address
     build: ../Peer
     volumes:
       - type: volume
         source: p02b
         target: /app
-    networks:
-      - pdc-net
     depends_on:
       - router1
       - router2


### PR DESCRIPTION
Removed uses of pdc-net, added in Dillon's change of multiple targets to all files, and changed IP addresses to service names in the compose files